### PR TITLE
Add regexp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ strum_macros = "0.23.1"
 escape8259 = "0.5"
 base64 = "0.13"
 thiserror = "1.0"
+regex = "1.5.4"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ Supported CDDL features:
 - Turn a group into a choice (`&`)
 - Map keys with cut syntax (`^ =>`)
 - Generic types
-- Control operator `.size`
+- Control operators `.size` and `.regexp`
 
 Unimplemented CDDL features:
 - Extend type with `/=`
 - Extend group with `//=`
 - Type sockets with `$`
 - Group sockets with `$$`
-- Control operators other than `.size` (e.g. `.bits`, `.regexp` ...)
+- Control operators other than those above (e.g. `.bits`, `lt`, `gt`...)
 - Group enumeration with `&`
 - Tagged data with `#`
 - Hexfloat literals (e.g. `0x1.921fb5p+1`)

--- a/src/ivt.rs
+++ b/src/ivt.rs
@@ -376,6 +376,8 @@ impl fmt::Display for Range {
 pub enum Control {
     /// Limit the size in bytes.
     Size(CtlOpSize),
+    /// Apply a regular expression to a text string.
+    Regexp(CtlOpRegexp),
 }
 
 /// Control Operator `.size`
@@ -394,6 +396,24 @@ pub struct CtlOpSize {
     pub target: Box<Node>,
     /// The size limit, in bytes.
     pub size: Box<Node>,
+}
+
+/// Control Operator `.regexp`
+///
+/// `.regexp` is defined in RFC 8610 3.8.3.
+///
+#[derive(Debug, Clone)]
+pub struct CtlOpRegexp {
+    /// The regular expression, in compiled form.
+    pub(crate) re: regex::Regex,
+}
+
+impl PartialEq for CtlOpRegexp {
+    fn eq(&self, other: &Self) -> bool {
+        // We only need to compare the string form,
+        // not the compiled form.
+        self.re.as_str() == other.re.as_str()
+    }
 }
 
 /// Any node in the Intermediate Validation Tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,14 +102,14 @@
 //! - Turn a group into a choice (`&`)
 //! - Map keys with cut syntax (`^ =>`)
 //! - Generic types
-//! - Control operator `.size`
+//! - Control operators `.size` and `.regexp`
 //!
 //! Unimplemented CDDL features:
 //! - Extend type with `/=`
 //! - Extend group with `//=`
 //! - Type sockets with `$`
 //! - Group sockets with `$$`
-//! - Control operators other than `.size` (e.g. `.bits`, `.regexp` ...)
+//! - Control operators other than those above (e.g. `.bits`, `lt`, `gt`...)
 //! - Group enumeration with `&`
 //! - Tagged data with `#`
 //! - Hexfloat literals (e.g. `0x1.921fb5p+1`)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1045,6 +1045,7 @@ where
 fn validate_control(ctl: &Control, value: &Value, ctx: &Context) -> ValidateResult {
     match ctl {
         Control::Size(ctl_size) => validate_control_size(ctl_size, value, ctx),
+        Control::Regexp(re) => validate_control_regexp(re, value),
     }
 }
 
@@ -1083,6 +1084,23 @@ fn validate_control_size(ctl: &CtlOpSize, value: &Value, ctx: &Context) -> Valid
             }
         }
     })
+}
+
+/// Validate the control operator "regexp"
+///
+/// `regexp` applies a regular expression to a text string.
+///
+fn validate_control_regexp(re: &CtlOpRegexp, value: &Value) -> ValidateResult {
+    match value {
+        Value::Text(text) => {
+            if re.re.is_match(text) {
+                Ok(())
+            } else {
+                Err(mismatch("regex mismatch"))
+            }
+        }
+        _ => Err(mismatch("tstr")),
+    }
 }
 
 fn validate_size_uint(size: u64, value: &Value) -> ValidateResult {


### PR DESCRIPTION
This adds support for the control operator .regexp, which applies a regular expression to a text string.
    
It uses the Rust regex crate, which isn't guaranteed to match the XSD behavior requested by RFC8610. But it seems close enough for real-world use.

Closes #1.
