### PR TITLE
Add support for .cbor control operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Supported CDDL features:
 - Turn a group into a choice (`&`)
 - Map keys with cut syntax (`^ =>`)
 - Generic types
-- Control operators `.size` and `.regexp`
+- Control operators `.cbor`, `.size` and `.regexp`
 
 Unimplemented CDDL features:
 - Extend type with `/=`

--- a/src/ivt.rs
+++ b/src/ivt.rs
@@ -378,6 +378,8 @@ pub enum Control {
     Size(CtlOpSize),
     /// Apply a regular expression to a text string.
     Regexp(CtlOpRegexp),
+    /// Validate a nested CBOR bytestring
+    Cbor(CtlOpCbor),
 }
 
 /// Control Operator `.size`
@@ -414,6 +416,19 @@ impl PartialEq for CtlOpRegexp {
         // not the compiled form.
         self.re.as_str() == other.re.as_str()
     }
+}
+
+/// Control Operator `.cbor`
+///
+/// `.cbor` is defined in RFC 8610 3.8.4
+///
+/// A ".cbor" control on a byte string indicates that the byte string
+/// carries a CBOR-encoded data item.  Decoded, the data item matches the
+/// type given as the right-hand-side argument.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CtlOpCbor {
+    /// The nested node to satisfy
+    pub(crate) node: Box<Node>,
 }
 
 /// Any node in the Intermediate Validation Tree.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -9,7 +9,6 @@ use crate::value::Value;
 use std::collections::BTreeMap; // used in Value::Map
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::mem::discriminant;
 
@@ -1051,27 +1050,28 @@ fn validate_control(ctl: &Control, value: &Value, ctx: &Context) -> ValidateResu
     }
 }
 
+#[cfg(not(feature = "serde_cbor"))]
+fn validate_control_cbor(_ctl_cbor: &CtlOpCbor, _value: &Value, _ctx: &Context) -> ValidateResult {
+    Err(ValidateError::Unsupported(
+        "'.cbor' control operator; enable serde_cbor feature to support.".into(),
+    ))
+}
+
+#[cfg(feature = "serde_cbor")]
 fn validate_control_cbor(ctl_cbor: &CtlOpCbor, value: &Value, ctx: &Context) -> ValidateResult {
-    if cfg!(feature = "serde_cbor") {
-        use serde_cbor::Value as CBOR_Value;
+    use serde_cbor::Value as CBOR_Value;
+    use std::convert::TryFrom;
 
-        match value {
-            Value::Bytes(bytes) => {
-                let cbor_value: CBOR_Value = serde_cbor::from_slice(bytes)
-                    .map_err(|e| ValidateError::ValueError(format!("{}", e)))?;
+    match value {
+        Value::Bytes(bytes) => {
+            let cbor_value: CBOR_Value = serde_cbor::from_slice(bytes)
+                .map_err(|e| ValidateError::ValueError(format!("{}", e)))?;
 
-                let nested_value = Value::try_from(cbor_value)?;
+            let nested_value = Value::try_from(cbor_value)?;
 
-                validate(&nested_value, ctl_cbor.node.as_ref(), ctx)
-            }
-            _ => Err::<(), ValidateError>(mismatch("Bytes")),
-        }?;
-
-        Ok(())
-    } else {
-        Err(ValidateError::Unsupported(
-            "'.cbor' control operator; enable serde_cbor feature to support.".into(),
-        ))
+            validate(&nested_value, ctl_cbor.node.as_ref(), ctx)
+        }
+        _ => Err::<(), ValidateError>(mismatch("Bytes")),
     }
 }
 

--- a/tests/cbor_cddl.rs
+++ b/tests/cbor_cddl.rs
@@ -38,6 +38,7 @@ pub mod cbor {
     pub const BYTES_EMPTY:  &[u8] = b"\x40";
     pub const BYTES_1234:   &[u8] = b"\x44\x01\x02\x03\x04"; // hex 01020304
 
+    pub const CBOR_INT_23:  &[u8] = b"\x41\x17"; // cbor(23)
 }
 
 #[test]
@@ -690,6 +691,24 @@ fn cbor_control_size() {
 
     let cddl_input = r#"thing = bstr .size -1"#;
     validate_cbor_bytes("thing", cddl_input, cbor::BYTES_EMPTY).unwrap_err();
+}
+
+#[test]
+fn cbor_control_cbor() {
+    let cddl_input = r#"thing = bytes .cbor uint"#;
+    validate_cbor_bytes("thing", cddl_input, cbor::CBOR_INT_23).unwrap();
+
+    let cddl_input = r#"
+        thing = bytes .cbor foo
+        foo = uint
+    "#;
+    validate_cbor_bytes("thing", cddl_input, cbor::CBOR_INT_23).unwrap();
+
+    let cddl_input = r#"
+        thing = bytes .cbor foo<uint>
+        foo<t> = t
+    "#;
+    validate_cbor_bytes("thing", cddl_input, cbor::CBOR_INT_23).unwrap();
 }
 
 #[track_caller]


### PR DESCRIPTION
This operator is pretty useful for embedding CBOR in CBOR; and relatively low-hanging fruit to implement as we can recursively re-use the existing validation.

- [x] Implemented validation
- [x] Fixed CDDL parser 
- [x] Added few unit tests 
- [x] Updated README.md 

> **Note**
> Since the validation rely on `serde_cbor`, I've only conditionally included it. If the library is imported without that feature, then the behavior is more or less the current one (i.e. a Validation failure for an unsupported control operator). 